### PR TITLE
Add configurability and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+target/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# webScraper
-scraper to scrape wikipedia to google sheets
+# WebScraper (Spring Boot)
+
+This project demonstrates how to use a set of RPA style steps to scrape the first ten rows of the "List of FIFA World Cup finals" table on Wikipedia and optionally append that data to a Google Sheet. The application exposes two HTTP endpoints for Postman testing.
+
+## Setup
+
+Ensure you have **Java 17** and **Maven** installed. Clone the repository and build:
+
+```bash
+mvn package
+```
+
+## Running
+
+Start the Spring Boot application:
+
+```bash
+mvn spring-boot:run
+```
+
+### API Endpoints
+
+- `GET /api/finals` – returns the scraped table rows as JSON.
+- `POST /api/append` – scrapes and appends the rows to a Google Sheet. Provide JSON body with `spreadsheetId`, `accessToken` and optional `range` (defaults to `Sheet1!A1:D1`).
+
+## Configuration
+
+Application settings are defined in `src/main/resources/application.properties` and can be overridden via environment variables or command line arguments.
+
+- `scraper.url` – Wikipedia URL to scrape
+- `scraper.table.selector` – CSS selector for the table rows
+- `scraper.limit` – how many rows to capture
+- `google.api.base` – base URL for the Sheets API
+- `sheet.default.range` – default cell range when appending
+
+Detailed logs are emitted for each step and API call using SLF4J.
+
+No configuration is required to read data. Provide an OAuth `accessToken` when calling `/api/append` to update a sheet.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>webscraper</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <java.version>17</java.version>
+        <spring.boot.version>3.2.5</spring.boot.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.17.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/webscraper/WebScraperApplication.java
+++ b/src/main/java/com/example/webscraper/WebScraperApplication.java
@@ -1,0 +1,14 @@
+package com.example.webscraper;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Entry point for the Spring Boot application.
+ */
+@SpringBootApplication
+public class WebScraperApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(WebScraperApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/webscraper/controller/ApiController.java
+++ b/src/main/java/com/example/webscraper/controller/ApiController.java
@@ -1,0 +1,76 @@
+package com.example.webscraper.controller;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.example.webscraper.model.FinalResult;
+import com.example.webscraper.service.ScrapeService;
+import com.example.webscraper.service.SheetService;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * REST endpoints for scraping and appending to Google Sheets.
+ */
+@RestController
+@RequestMapping("/api")
+public class ApiController {
+
+    private static final Logger log = LoggerFactory.getLogger(ApiController.class);
+
+    @Value("${sheet.default.range:Sheet1!A1:D1}")
+    private String defaultRange;
+
+    private final ScrapeService scrapeService;
+    private final SheetService sheetService;
+
+    public ApiController(ScrapeService scrapeService, SheetService sheetService) {
+        this.scrapeService = scrapeService;
+        this.sheetService = sheetService;
+    }
+
+    /**
+     * Returns the scraped finals as JSON.
+     *
+     * @return list of finals from Wikipedia
+     */
+    @GetMapping("/finals")
+    public List<FinalResult> getFinals() throws IOException {
+        log.info("GET /api/finals");
+        return scrapeService.scrapeFinals();
+    }
+
+    /**
+     * Scrapes and appends the finals to Google Sheets.
+     *
+     * @param body JSON body containing `spreadsheetId`, `accessToken` and optional `range`
+     * @return result from Google Sheets API
+     */
+    @PostMapping("/append")
+    public ResponseEntity<?> append(@RequestBody Map<String, String> body) {
+        String spreadsheetId = body.get("spreadsheetId");
+        String accessToken = body.get("accessToken");
+        String range = body.getOrDefault("range", defaultRange);
+        if (spreadsheetId == null || accessToken == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("error", "spreadsheetId and accessToken are required"));
+        }
+        try {
+            log.info("Appending finals to sheet {} range {}", spreadsheetId, range);
+            List<FinalResult> finals = scrapeService.scrapeFinals();
+            JsonNode result = sheetService.appendToSheet(spreadsheetId, range, finals, accessToken);
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            log.error("Failed to append", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/example/webscraper/model/FinalResult.java
+++ b/src/main/java/com/example/webscraper/model/FinalResult.java
@@ -1,0 +1,34 @@
+package com.example.webscraper.model;
+
+/**
+ * Represents a row from the FIFA World Cup finals table.
+ */
+public class FinalResult {
+    private Integer year;
+    private String winner;
+    private String score;
+    private String runnerUp;
+
+    public FinalResult(Integer year, String winner, String score, String runnerUp) {
+        this.year = year;
+        this.winner = winner;
+        this.score = score;
+        this.runnerUp = runnerUp;
+    }
+
+    public Integer getYear() {
+        return year;
+    }
+
+    public String getWinner() {
+        return winner;
+    }
+
+    public String getScore() {
+        return score;
+    }
+
+    public String getRunnerUp() {
+        return runnerUp;
+    }
+}

--- a/src/main/java/com/example/webscraper/service/ScrapeService.java
+++ b/src/main/java/com/example/webscraper/service/ScrapeService.java
@@ -1,0 +1,57 @@
+package com.example.webscraper.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.example.webscraper.model.FinalResult;
+import com.example.webscraper.steps.StepUtils;
+
+/**
+ * Service that performs scraping using the RPA-style steps.
+ */
+@Service
+public class ScrapeService {
+    private static final Logger log = LoggerFactory.getLogger(ScrapeService.class);
+
+    @Value("${scraper.url:https://en.wikipedia.org/wiki/List_of_FIFA_World_Cup_finals}")
+    private String url;
+
+    @Value("${scraper.table.selector:table.wikitable.sortable tbody > tr}")
+    private String tableSelector;
+
+    @Value("${scraper.limit:10}")
+    private int limit;
+    /**
+     * Scrapes the configured number of FIFA World Cup finals from the page.
+     *
+     * @return list of finals extracted using {@link StepUtils}
+     */
+    public List<FinalResult> scrapeFinals() throws IOException {
+        log.info("Scraping finals from {}", url);
+        Document doc = StepUtils.openPage(url);
+        Elements rows = doc.select(tableSelector)
+            .stream()
+            .filter(el -> !el.select("th[scope=row]").isEmpty())
+            .limit(limit)
+            .collect(java.util.stream.Collectors.toCollection(Elements::new));
+        List<FinalResult> results = new ArrayList<>();
+        StepUtils.loop(rows.stream().toList(), (Element row, Integer idx) -> {
+            Elements cells = row.select("th, td");
+            Integer year = StepUtils.parseNumber(StepUtils.extractHTML(cells.get(0), null));
+            String winner = StepUtils.extractHTML(cells.get(1), null);
+            String score = StepUtils.extractHTML(cells.get(2), null);
+            String runnerUp = StepUtils.extractHTML(cells.get(3), null);
+            results.add(new FinalResult(year, winner, score, runnerUp));
+        });
+        return results;
+    }
+}

--- a/src/main/java/com/example/webscraper/service/SheetService.java
+++ b/src/main/java/com/example/webscraper/service/SheetService.java
@@ -1,0 +1,55 @@
+package com.example.webscraper.service;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.example.webscraper.model.FinalResult;
+import com.example.webscraper.steps.StepUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Service for interacting with Google Sheets via the API.
+ */
+@Service
+public class SheetService {
+    private static final Logger log = LoggerFactory.getLogger(SheetService.class);
+
+    @Value("${google.api.base:https://sheets.googleapis.com}")
+    private String apiBase;
+
+    /**
+     * Appends the provided finals data to the specified Google Sheet.
+     *
+     * @param spreadsheetId Google Sheet identifier
+     * @param range cell range to append to
+     * @param finals rows extracted from Wikipedia
+     * @param accessToken OAuth access token
+     * @return JSON response from Google Sheets API
+     */
+    public JsonNode appendToSheet(String spreadsheetId, String range, List<FinalResult> finals, String accessToken)
+            throws IOException, InterruptedException {
+        String url = apiBase + "/v4/spreadsheets/" + spreadsheetId + "/values/"
+                + java.net.URLEncoder.encode(range, java.nio.charset.StandardCharsets.UTF_8)
+                + ":append?valueInputOption=USER_ENTERED";
+        log.info("Appending {} rows to spreadsheet {}", finals.size(), spreadsheetId);
+        List<List<String>> rows = finals.stream()
+                .map(f -> List.of(
+                        f.getYear() == null ? "" : f.getYear().toString(),
+                        f.getWinner(),
+                        f.getScore(),
+                        f.getRunnerUp()))
+                .toList();
+        String body = new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(Map.of("values", rows));
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", "application/json");
+        headers.put("Authorization", "Bearer " + accessToken);
+        return StepUtils.callAPI(url, "POST", headers, body);
+    }
+}

--- a/src/main/java/com/example/webscraper/steps/StepUtils.java
+++ b/src/main/java/com/example/webscraper/steps/StepUtils.java
@@ -1,0 +1,111 @@
+package com.example.webscraper.steps;
+
+import java.io.IOException;
+import java.net.*;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Utility methods that mirror the provided RPA step descriptions.
+ */
+public class StepUtils {
+    private static final Logger log = LoggerFactory.getLogger(StepUtils.class);
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    /** Opens a webpage and returns a Jsoup Document. */
+    public static Document openPage(String url) throws IOException {
+        log.info("Opening page {}", url);
+        String proxyUrl = System.getenv("https_proxy");
+        if (proxyUrl == null) {
+            proxyUrl = System.getenv("http_proxy");
+        }
+        if (proxyUrl != null) {
+            try {
+                URL proxy = new URL(proxyUrl);
+                Proxy javaProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxy.getHost(), proxy.getPort()));
+                return Jsoup.connect(url).proxy(javaProxy).get();
+            } catch (MalformedURLException e) {
+                log.warn("Invalid proxy URL: {}", proxyUrl);
+            }
+        }
+        return Jsoup.connect(url).get();
+    }
+
+    /** Converts a string representation of a number into an Integer. */
+    public static Integer parseNumber(String text) {
+        log.info("Parsing number from '{}'", text);
+        String digits = text.replaceAll("[^0-9-]", "");
+        if (digits.isEmpty()) {
+            return null;
+        }
+        return Integer.parseInt(digits);
+    }
+
+    /**
+     * Iterates over a list, executing the consumer for each element.
+     * The index starts from 1.
+     */
+    public static <T> void loop(List<T> list, BiConsumer<T, Integer> consumer) {
+        for (int i = 0; i < list.size(); i++) {
+            int index = i + 1;
+            log.info("Loop iteration {}", index);
+            consumer.accept(list.get(i), index);
+        }
+    }
+
+    /** Extracts text from an element, optionally using a CSS selector. */
+    public static String extractHTML(Element element, String selector) {
+        String text = selector == null ? element.text() : element.select(selector).text();
+        text = text.trim();
+        log.info("Extracted text: '{}'", text);
+        return text;
+    }
+
+    /** Makes an HTTP request similar to calling an API from Postman. */
+    public static JsonNode callAPI(String url, String method, Map<String, String> headers, String body) throws IOException, InterruptedException {
+        log.info("Calling API {} {}", method, url);
+        HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(30))
+                .method(method, body == null ? HttpRequest.BodyPublishers.noBody() : HttpRequest.BodyPublishers.ofString(body));
+        if (headers != null) {
+            headers.forEach(builder::header);
+        }
+        HttpRequest request = builder.build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= 400) {
+            throw new IOException("API request failed: " + response.statusCode() + " " + response.body());
+        }
+        return mapper.readTree(response.body());
+    }
+
+    /** Executes a branch if condition is true. */
+    public static void detour(boolean condition, Runnable runnable) {
+        log.info("Detour condition: {}", condition);
+        if (condition) {
+            runnable.run();
+        }
+    }
+
+    // Placeholders for additional steps
+    public static void fillTextField() {}
+    public static void click() {}
+    public static void checkBox() {}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+# Server configuration
+server.port=8080
+
+# Scraper configuration
+scraper.url=https://en.wikipedia.org/wiki/List_of_FIFA_World_Cup_finals
+scraper.table.selector=table.wikitable.sortable tbody > tr
+scraper.limit=10
+
+# Google Sheets configuration
+google.api.base=https://sheets.googleapis.com
+sheet.default.range=Sheet1!A1:D1


### PR DESCRIPTION
## Summary
- load scraper and Sheets settings from `application.properties`
- document configuration options in the README
- log scraping and append operations with SLF4J
- annotate endpoints and services with Javadoc comments

## Testing
- `mvn -q package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a14b84f08320a6251709f240f4f6